### PR TITLE
:sparkles: Config Updater

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "documentation",
   "version": "1.0.0",
   "description": "Documentation for all projects made by the LeavesMC team.",
+  "type": "module",
   "scripts": {
     "dev": "vitepress dev",
     "build": "vitepress build",
-    "preview": "vitepress preview"
+    "preview": "vitepress preview",
+    "leaves-config": "node scripts/update-config.js src/config-spec/leaves leaves"
   },
   "author": "LittleChest",
   "license": "MPL-2.0",
@@ -17,6 +19,7 @@
     "@nolebase/vitepress-plugin-enhanced-mark": "2.0.0-rc2",
     "@nolebase/vitepress-plugin-enhanced-readabilities": "1.28.0",
     "@types/node": "^20.12.12",
+    "node-fetch": "^3.3.2",
     "prettier": "3.2.5",
     "vitepress": "1.2.2",
     "vitepress-plugin-nprogress": "^0.0.4"

--- a/scripts/update-config.js
+++ b/scripts/update-config.js
@@ -12,11 +12,11 @@ const onlineConfig = {
 };
 
 if (!configPath) {
-  console.error("Error: Please specify a directory or file.");
+  throw new Error("Please specify a directory or file.");
 }
 
 if (!onlineConfig.hasOwnProperty(software)) {
-  console.error("Error: Unknown software.");
+  throw new Error("Unknown software.");
 }
 
 async function downloadConfig(type) {
@@ -123,7 +123,7 @@ async function updateConfig(files, baseConfig) {
         console.log(`Updated: ${filePath}`);
       } catch (error) {
         console.error(`Failed to update the configuration file: ${filePath}`);
-        console.error(error.stack || error.message);
+        throw new Error(error.stack || error.message);
       }
     })
   );
@@ -137,7 +137,7 @@ try {
     if (path.extname(configPath) === ".yml") {
       await updateConfig([configPath], baseConfig);
     } else {
-      console.error("Error: This is not a valid configuration file.");
+      throw new Error("This is not a valid configuration file.");
     }
   } else if (stats.isDirectory()) {
     const files = await fs.promises.readdir(configPath);
@@ -146,11 +146,11 @@ try {
       .map((file) => path.join(configPath, file));
 
     if (ymlFiles.length === 0) {
-      console.error("Error: No configuration files found in this directory.");
+      throw new Error("No configuration files found in this directory.");
     }
 
     await updateConfig(ymlFiles, baseConfig);
   }
 } catch (error) {
-  console.error("Error:", error.message);
+  throw new Error(error.message);
 }

--- a/scripts/update-config.js
+++ b/scripts/update-config.js
@@ -1,0 +1,128 @@
+import fs from "fs";
+import path from "path";
+import yaml from "yaml";
+import fetch from "node-fetch";
+
+const configPath = process.argv[2];
+const software = process.argv[3] || "leaves";
+
+const onlineConfig = {
+  leaves:
+    "https://raw.githubusercontent.com/LeavesMC/Configuration/refs/heads/Leaves/leaves.yml",
+};
+
+if (!configPath) {
+  console.error("Error: Please specify a directory or file.");
+}
+
+if (!onlineConfig.hasOwnProperty(software)) {
+  console.error("Error: Unknown software.");
+}
+
+async function downloadConfig(type) {
+  const url = onlineConfig[type];
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const config = await response.text();
+  return config;
+}
+
+function valueHandler(value) {
+  if (Array.isArray(value)) {
+    return { default: value, description: "" };
+  }
+
+  if (
+    typeof value === "string" &&
+    (value.toLowerCase() === "true" || value.toLowerCase() === "false")
+  ) {
+    return { default: `'${value}'`, description: "" };
+  }
+  return { default: String(value), description: "" };
+}
+
+function configHandler(obj, oldConfig = null, updated = new WeakSet()) {
+  if (updated.has(obj)) {
+    throw new Error("Circular reference found.");
+  }
+
+  if (Array.isArray(obj)) {
+    const updatedValue = valueHandler(obj);
+    if (oldConfig && oldConfig.description) {
+      updatedValue.description = oldConfig.description;
+    }
+    return updatedValue;
+  }
+
+  if (typeof obj === "object" && obj !== null) {
+    updated.add(obj);
+    const result = {};
+    for (const [key, value] of Object.entries(obj)) {
+      const oldValue = oldConfig?.[key];
+      result[key] = configHandler(value, oldValue, updated);
+    }
+    updated.delete(obj);
+    return result;
+  }
+
+  const updatedValue = valueHandler(obj);
+  if (oldConfig && oldConfig.description) {
+    updatedValue.description = oldConfig.description;
+  }
+  return updatedValue;
+}
+
+async function updateConfig(files, baseConfig) {
+  return Promise.all(
+    files.map(async (filePath) => {
+      try {
+        let oldConfig = null;
+
+        const existingConfig = await fs.promises.readFile(filePath, "utf8");
+        if (existingConfig.trim()) {
+          oldConfig = yaml.parse(existingConfig);
+        }
+
+        const config = yaml.parse(baseConfig);
+        const updatedConfig = yaml.stringify(configHandler(config, oldConfig));
+
+        await fs.promises.writeFile(filePath, updatedConfig, "utf8");
+        console.log(`Updated: ${filePath}`);
+      } catch (error) {
+        console.error(`Failed to update the configuration file: ${filePath}`);
+        console.error(error.stack || error.message);
+      }
+    })
+  );
+}
+
+try {
+  const stats = await fs.promises.stat(configPath);
+  const baseConfig = await downloadConfig(software);
+
+  if (stats.isFile()) {
+    if (path.extname(configPath) === ".yml") {
+      await updateConfig([configPath], baseConfig);
+    } else {
+      console.error("Error: This is not a valid configuration file.");
+    }
+  } else if (stats.isDirectory()) {
+    const files = await fs.promises.readdir(configPath);
+    const ymlFiles = files
+      .filter((file) => path.extname(file) === ".yml")
+      .map((file) => path.join(configPath, file));
+
+    if (ymlFiles.length === 0) {
+      console.error("Error: No configuration files found in this directory.");
+    }
+
+    await updateConfig(ymlFiles, baseConfig);
+  }
+} catch (error) {
+  console.error("Error:", error.message);
+}


### PR DESCRIPTION
#### 下载最新的配置文件并将其转为文档使用的配置文件模板，支持从旧配置迁移。

用法：`update-config <路径> [软件]`

默认的软件为 [Leaves](https://github.com/LeavesMC/Leaves)。

---

路径为文件夹时将查找并更新文件夹下的所有 `yml` 文件。

路径必须存在！因此要创建一个全新的配置文件（例如添加新语言支持），可以新建并指定一个空文件。

若指定的路径是已存在的配置文件，则会自动从旧配置文件中获取 `description` 字段并填充至新配置文件。