### PR TITLE
Update zh_Hans.yml

### DIFF
--- a/src/config-spec/leaves/zh_Hans.yml
+++ b/src/config-spec/leaves/zh_Hans.yml
@@ -719,7 +719,7 @@ settings:
         :::
     vanilla-display-name:
       default: "false"
-      description: 是否将聊天中的玩家名解析为 [文本组件](https://zh.minecraft.wiki/w/%E6%96%87%E6%9C%AC%E7%BB%84%E4%BB%B6s)，这会影响到玩家名改变颜色等功能。
+      description: 是否将聊天中的玩家名解析为 [文本组件](https://zh.minecraft.wiki/w/%E6%96%87%E6%9C%AC%E7%BB%84%E4%BB%B6)，这会影响到玩家名改变颜色等功能。
     collision-behavior:
       default: BLOCK_SHAPE_VANILLA
       description: |


### PR DESCRIPTION
修复配置介绍vanilla-display-name 栏目中, 对Minecraft Wiki 相应 文本组件 页面的引用链接
(原链接后面多加了个 's' , 猜想应该是按ctrl+s的时候没弄好 (小声) )